### PR TITLE
Improve BNV training features

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,14 +34,17 @@ The resulting model will be saved in the `./bnv_model` directory.
 
 If you do not have local datasets, you can train using text fetched from
 several open APIs. Enable this with the `--use-live-data` flag. You can also
-specify Wikipedia topics used for the summaries:
+specify Wikipedia topics used for the summaries and search queries to gather
+web snippets:
 
 ```bash
-python -m bnv.train --use-live-data --wiki-topics Machine_learning Python
+python -m bnv.train --use-live-data --wiki-topics Machine_learning Python \
+    --search-queries "latest AI news" "open source llm"
 ```
 
 This downloads short passages from Wikipedia along with samples from the
-Quotable, Bored, RandomUser and Open‑Meteo APIs to create a small training set.
+Quotable, Bored, RandomUser, Open‑Meteo and DuckDuckGo APIs to create a small
+training set.
 
 ## Generating text or code
 
@@ -90,6 +93,6 @@ print(text)
 ### Data sources
 
 The `bnv.data_sources` module provides helper functions for retrieving text
-from free APIs, including Wikipedia, Quotable, Bored, RandomUser and
-Open‑Meteo. These functions are used when training with the `--use-live-data`
-flag but can also be called directly.
+from free APIs, including Wikipedia, Quotable, Bored, RandomUser,
+Open‑Meteo and DuckDuckGo search. These functions are used when training with
+the `--use-live-data` flag but can also be called directly.

--- a/README.md
+++ b/README.md
@@ -28,3 +28,15 @@ python -m bnv.train --output ./bnv_model --model distilgpt2 \
 ```
 
 The resulting model will be saved in the `./bnv_model` directory.
+
+## Generating text or code
+
+After training, use the `bnv.generate` module to produce text or code from
+your model. Provide the path to the saved model and a prompt:
+
+```bash
+python -m bnv.generate --model ./bnv_model --prompt "Write a Python function to add two numbers"
+```
+
+The generation speed depends on your hardware, so responses may take longer
+than a few milliseconds on typical machines.

--- a/README.md
+++ b/README.md
@@ -40,3 +40,32 @@ python -m bnv.generate --model ./bnv_model --prompt "Write a Python function to 
 
 The generation speed depends on your hardware, so responses may take longer
 than a few milliseconds on typical machines.
+
+## Capabilities
+
+The `bnv.capabilities` module exposes a set of helper functions built on top of
+the trained BNV model. These functions provide convenient prompts for common
+text and code tasks:
+
+1. `generate_text` – free‑form text generation
+2. `generate_code` – create code from a natural language description
+3. `summarize_text` – produce a concise summary of longer passages
+4. `translate_text` – translate text into another language
+5. `explain_code` – explain what a piece of code does
+6. `refactor_code` – suggest improvements for existing code
+7. `generate_docstring` – write docstrings for Python functions
+8. `answer_question` – respond to questions with optional context
+9. `autocomplete_code` – complete partially written code
+10. `commit_message` – draft a concise commit message from a diff
+11. `style_transfer` – rewrite text in a specified style
+12. `code_review` – provide a short code review with improvement tips
+
+Import the module and call these helpers after you have trained or downloaded a
+model:
+
+```python
+from bnv import capabilities
+
+text = capabilities.summarize_text("./bnv_model", "Long text to summarize")
+print(text)
+```

--- a/README.md
+++ b/README.md
@@ -59,6 +59,9 @@ text and code tasks:
 10. `commit_message` – draft a concise commit message from a diff
 11. `style_transfer` – rewrite text in a specified style
 12. `code_review` – provide a short code review with improvement tips
+13. `step_by_step_reasoning` – answer questions with detailed reasoning
+14. `plan_program` – outline a program before implementation
+15. `debug_reasoning` – walk through bug discovery and fixes
 
 Import the module and call these helpers after you have trained or downloaded a
 model:

--- a/README.md
+++ b/README.md
@@ -1,1 +1,30 @@
-# bnv
+# BNV
+
+BNV is a simple example project that demonstrates how to fine-tune a small
+language model for both text and code generation tasks. The `train.py` script
+uses Hugging Face Transformers and the `datasets` library to combine the
+`wikitext` dataset with a small code corpus and trains a model based on
+`distilgpt2`.
+
+## Requirements
+
+- Python 3.12+
+- `torch`, `transformers`, and `datasets`
+
+Install the dependencies with pip:
+
+```bash
+pip install torch==2.2.1 torchvision torchaudio transformers datasets
+```
+
+## Training
+
+Run the training script to produce the BNV model. The training script supports
+adjusting epochs, batch size, and generating a sample after training:
+
+```bash
+python -m bnv.train --output ./bnv_model --model distilgpt2 \
+    --epochs 3 --batch-size 4 --sample-prompt "def hello():"
+```
+
+The resulting model will be saved in the `./bnv_model` directory.

--- a/README.md
+++ b/README.md
@@ -10,11 +10,12 @@ uses Hugging Face Transformers and the `datasets` library to combine the
 
 - Python 3.12+
 - `torch`, `transformers`, and `datasets`
+- `requests`
 
 Install the dependencies with pip:
 
 ```bash
-pip install torch==2.2.1 torchvision torchaudio transformers datasets
+pip install torch==2.2.1 torchvision torchaudio transformers datasets requests
 ```
 
 ## Training
@@ -28,6 +29,19 @@ python -m bnv.train --output ./bnv_model --model distilgpt2 \
 ```
 
 The resulting model will be saved in the `./bnv_model` directory.
+
+### Using live data sources
+
+If you do not have local datasets, you can train using text fetched from
+several open APIs. Enable this with the `--use-live-data` flag. You can also
+specify Wikipedia topics used for the summaries:
+
+```bash
+python -m bnv.train --use-live-data --wiki-topics Machine_learning Python
+```
+
+This downloads short passages from Wikipedia along with samples from the
+Quotable, Bored, RandomUser and Open‑Meteo APIs to create a small training set.
 
 ## Generating text or code
 
@@ -72,3 +86,10 @@ from bnv import capabilities
 text = capabilities.summarize_text("./bnv_model", "Long text to summarize")
 print(text)
 ```
+
+### Data sources
+
+The `bnv.data_sources` module provides helper functions for retrieving text
+from free APIs, including Wikipedia, Quotable, Bored, RandomUser and
+Open‑Meteo. These functions are used when training with the `--use-live-data`
+flag but can also be called directly.

--- a/bnv/__init__.py
+++ b/bnv/__init__.py
@@ -1,6 +1,11 @@
 """BNV: A simple text and code generation model."""
 
-__all__ = ["train", "generate"]
+__all__ = [
+    "train",
+    "generate",
+    "capabilities",
+]
 
 from .train import train
 from .generate import generate
+from . import capabilities

--- a/bnv/__init__.py
+++ b/bnv/__init__.py
@@ -4,8 +4,10 @@ __all__ = [
     "train",
     "generate",
     "capabilities",
+    "data_sources",
 ]
 
 from .train import train
 from .generate import generate
 from . import capabilities
+from . import data_sources

--- a/bnv/__init__.py
+++ b/bnv/__init__.py
@@ -1,0 +1,5 @@
+"""BNV: A simple text and code generation model."""
+
+__all__ = ["train"]
+
+from .train import train

--- a/bnv/__init__.py
+++ b/bnv/__init__.py
@@ -1,5 +1,6 @@
 """BNV: A simple text and code generation model."""
 
-__all__ = ["train"]
+__all__ = ["train", "generate"]
 
 from .train import train
+from .generate import generate

--- a/bnv/capabilities.py
+++ b/bnv/capabilities.py
@@ -84,3 +84,22 @@ def code_review(model_path: str, code: str, max_length: int = 200) -> str:
     """Provide a short code review."""
     prompt = f"Review the following code and suggest improvements:\n{code}\nReview:"
     return _generate(model_path, prompt, max_length)
+
+
+
+def step_by_step_reasoning(model_path: str, question: str, max_length: int = 200) -> str:
+    """Answer a question with step-by-step reasoning."""
+    prompt = f"Let's reason step by step to answer:\nQuestion: {question}\nReasoning:"
+    return _generate(model_path, prompt, max_length)
+
+
+def plan_program(model_path: str, description: str, max_length: int = 200) -> str:
+    """Generate a high-level plan for implementing a program."""
+    prompt = f"Provide a detailed plan for the following program:\n{description}\nPlan:"
+    return _generate(model_path, prompt, max_length)
+
+
+def debug_reasoning(model_path: str, code: str, max_length: int = 200) -> str:
+    """Explain the reasoning used to locate and fix bugs."""
+    prompt = f"Find bugs in the code and explain the reasoning:\n{code}\nReasoning:"
+    return _generate(model_path, prompt, max_length)

--- a/bnv/capabilities.py
+++ b/bnv/capabilities.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+from transformers import AutoModelForCausalLM, AutoTokenizer
+
+
+def _generate(model_path: str, prompt: str, max_length: int = 200) -> str:
+    """Helper to load the model and generate text."""
+    tokenizer = AutoTokenizer.from_pretrained(model_path)
+    model = AutoModelForCausalLM.from_pretrained(model_path)
+    inputs = tokenizer(prompt, return_tensors="pt")
+    outputs = model.generate(**inputs, max_length=max_length)
+    return tokenizer.decode(outputs[0], skip_special_tokens=True)
+
+
+def generate_text(model_path: str, prompt: str, max_length: int = 200) -> str:
+    """Free-form text generation."""
+    return _generate(model_path, prompt, max_length)
+
+
+def generate_code(model_path: str, description: str, max_length: int = 200) -> str:
+    """Generate code from a natural language description."""
+    prompt = f"Write code for the following task:\n{description}\nCode:"
+    return _generate(model_path, prompt, max_length)
+
+
+def summarize_text(model_path: str, text: str, max_length: int = 150) -> str:
+    """Summarize a block of text."""
+    prompt = f"Summarize the following text:\n{text}\nSummary:"
+    return _generate(model_path, prompt, max_length)
+
+
+def translate_text(model_path: str, text: str, target_language: str, max_length: int = 200) -> str:
+    """Translate text into the target language."""
+    prompt = f"Translate the following text to {target_language}:\n{text}\nTranslation:"
+    return _generate(model_path, prompt, max_length)
+
+
+def explain_code(model_path: str, code: str, max_length: int = 200) -> str:
+    """Generate a plain-language explanation of the given code."""
+    prompt = f"Explain what the following code does:\n{code}\nExplanation:"
+    return _generate(model_path, prompt, max_length)
+
+
+def refactor_code(model_path: str, code: str, max_length: int = 200) -> str:
+    """Suggest improvements to the given code."""
+    prompt = f"Improve the following code for clarity and performance:\n{code}\nImproved code:"
+    return _generate(model_path, prompt, max_length)
+
+
+def generate_docstring(model_path: str, code: str, max_length: int = 150) -> str:
+    """Generate a docstring for the given code snippet."""
+    prompt = f"Add a detailed Python docstring to the following function:\n{code}\n\n"""
+    return _generate(model_path, prompt, max_length)
+
+
+def answer_question(model_path: str, question: str, context: str | None = None, max_length: int = 200) -> str:
+    """Answer a question, optionally using additional context."""
+    if context:
+        prompt = f"Use the context to answer the question.\nContext:{context}\nQuestion:{question}\nAnswer:"
+    else:
+        prompt = f"Question:{question}\nAnswer:"
+    return _generate(model_path, prompt, max_length)
+
+
+def autocomplete_code(model_path: str, prefix: str, max_length: int = 100) -> str:
+    """Complete a partial code snippet."""
+    prompt = f"Complete the following code:\n{prefix}"
+    return _generate(model_path, prompt, max_length)
+
+
+def commit_message(model_path: str, diff: str, max_length: int = 100) -> str:
+    """Generate a commit message describing the diff."""
+    prompt = f"Write a concise git commit message for the following changes:\n{diff}\nMessage:"
+    return _generate(model_path, prompt, max_length)
+
+
+def style_transfer(model_path: str, text: str, style: str, max_length: int = 200) -> str:
+    """Rewrite text in a specified style."""
+    prompt = f"Rewrite the following text in {style} style:\n{text}\nRewritten:"
+    return _generate(model_path, prompt, max_length)
+
+
+def code_review(model_path: str, code: str, max_length: int = 200) -> str:
+    """Provide a short code review."""
+    prompt = f"Review the following code and suggest improvements:\n{code}\nReview:"
+    return _generate(model_path, prompt, max_length)

--- a/bnv/data_sources.py
+++ b/bnv/data_sources.py
@@ -54,12 +54,27 @@ def fetch_weather(latitude: float, longitude: float) -> str:
     return f"Current temperature: {temp}°C"
 
 
-def fetch_live_data(topics: list[str] | None = None) -> list[str]:
+def fetch_search_results(query: str) -> str:
+    """Return a short snippet for the given search query using DuckDuckGo."""
+    url = "https://api.duckduckgo.com/"
+    params = {"q": query, "format": "json", "no_redirect": 1, "no_html": 1}
+    resp = requests.get(url, params=params, headers={"User-Agent": USER_AGENT}, timeout=10)
+    resp.raise_for_status()
+    data = resp.json()
+    snippet = data.get("AbstractText") or data.get("Answer", "")
+    if not snippet and data.get("RelatedTopics"):
+        snippet = data["RelatedTopics"][0].get("Text", "")
+    return snippet
+
+
+def fetch_live_data(topics: list[str] | None = None, search_queries: list[str] | None = None) -> list[str]:
     """Collect text samples from several open APIs."""
     topics = topics or ["Artificial_intelligence"]
     samples = []
     for topic in topics:
         samples.append(fetch_wikipedia_summary(topic))
+    for query in search_queries or []:
+        samples.append(fetch_search_results(query))
     samples.append(fetch_random_quote())
     samples.append(fetch_random_activity())
     samples.append(fetch_random_user())

--- a/bnv/data_sources.py
+++ b/bnv/data_sources.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+import requests
+
+USER_AGENT = "bnv-data-fetcher/1.0"
+
+
+def fetch_wikipedia_summary(topic: str) -> str:
+    """Fetch a short summary from Wikipedia for the given topic."""
+    url = f"https://en.wikipedia.org/api/rest_v1/page/summary/{topic}"
+    resp = requests.get(url, headers={"User-Agent": USER_AGENT}, timeout=10)
+    resp.raise_for_status()
+    data = resp.json()
+    return data.get("extract", "")
+
+
+def fetch_random_quote() -> str:
+    """Return a random quote from the Quotable API."""
+    resp = requests.get("https://api.quotable.io/random", headers={"User-Agent": USER_AGENT}, timeout=10)
+    resp.raise_for_status()
+    return resp.json().get("content", "")
+
+
+def fetch_random_activity() -> str:
+    """Get a random activity suggestion from the Bored API."""
+    resp = requests.get("https://www.boredapi.com/api/activity", headers={"User-Agent": USER_AGENT}, timeout=10)
+    resp.raise_for_status()
+    return resp.json().get("activity", "")
+
+
+def fetch_random_user() -> str:
+    """Fetch a short description of a random user from randomuser.me."""
+    resp = requests.get("https://randomuser.me/api/", headers={"User-Agent": USER_AGENT}, timeout=10)
+    resp.raise_for_status()
+    data = resp.json()["results"][0]
+    first = data["name"]["first"]
+    last = data["name"]["last"]
+    city = data["location"]["city"]
+    return f"{first} {last} from {city}"
+
+
+def fetch_weather(latitude: float, longitude: float) -> str:
+    """Retrieve current weather information from the Open-Meteo API."""
+    url = (
+        "https://api.open-meteo.com/v1/forecast?latitude="
+        f"{latitude}&longitude={longitude}&current=temperature_2m"
+    )
+    resp = requests.get(url, headers={"User-Agent": USER_AGENT}, timeout=10)
+    resp.raise_for_status()
+    data = resp.json()
+    temp = data.get("current", {}).get("temperature_2m")
+    if temp is None:
+        return ""
+    return f"Current temperature: {temp}°C"
+
+
+def fetch_live_data(topics: list[str] | None = None) -> list[str]:
+    """Collect text samples from several open APIs."""
+    topics = topics or ["Artificial_intelligence"]
+    samples = []
+    for topic in topics:
+        samples.append(fetch_wikipedia_summary(topic))
+    samples.append(fetch_random_quote())
+    samples.append(fetch_random_activity())
+    samples.append(fetch_random_user())
+    samples.append(fetch_weather(35.0, 139.0))  # default coordinates (Tokyo)
+    return [s for s in samples if s]

--- a/bnv/generate.py
+++ b/bnv/generate.py
@@ -1,0 +1,31 @@
+import argparse
+from transformers import AutoTokenizer, AutoModelForCausalLM
+
+
+def generate(model_path: str, prompt: str, max_length: int = 200) -> None:
+    """Generate text or code given a prompt using a trained model."""
+    tokenizer = AutoTokenizer.from_pretrained(model_path)
+    model = AutoModelForCausalLM.from_pretrained(model_path)
+    inputs = tokenizer(prompt, return_tensors="pt")
+    outputs = model.generate(**inputs, max_length=max_length)
+    print(tokenizer.decode(outputs[0], skip_special_tokens=True))
+
+
+def main(argv: list[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(
+        description="Generate text or code using a trained BNV model"
+    )
+    parser.add_argument("--model", required=True, help="Path to the trained model")
+    parser.add_argument("--prompt", required=True, help="Generation prompt")
+    parser.add_argument(
+        "--max-length",
+        type=int,
+        default=200,
+        help="Maximum length of generated text",
+    )
+    args = parser.parse_args(argv)
+    generate(args.model, args.prompt, args.max_length)
+
+
+if __name__ == "__main__":
+    main()

--- a/bnv/train.py
+++ b/bnv/train.py
@@ -1,0 +1,114 @@
+import argparse
+import math
+from typing import List
+
+from datasets import load_dataset, Dataset
+from transformers import (
+    AutoTokenizer,
+    AutoModelForCausalLM,
+    DataCollatorForLanguageModeling,
+    Trainer,
+    TrainingArguments,
+)
+
+
+def load_text_and_code_datasets(train_ratio: float = 0.9) -> tuple[Dataset, Dataset]:
+    """Load text and code datasets, merge them and split into train and eval sets."""
+    text_ds = load_dataset("wikitext", "wikitext-2-raw-v1", split="train")
+    code_ds = load_dataset("codeparrot/github-jupyter-text", split="train")
+    combined = Dataset.from_dict(
+        {
+            "text": text_ds["text"] + code_ds["content"],
+        }
+    )
+    split = combined.train_test_split(train_ratio, shuffle=True)
+    return split["train"], split["test"]
+
+
+def tokenize_dataset(tokenizer, dataset: Dataset) -> Dataset:
+    return dataset.map(
+        lambda examples: tokenizer(examples["text"]),
+        batched=True,
+        remove_columns=["text"],
+    )
+
+
+def train(
+    output_dir: str = "./bnv_model",
+    model_name: str = "distilgpt2",
+    epochs: int = 1,
+    batch_size: int = 2,
+    train_ratio: float = 0.9,
+    sample_prompt: str | None = None,
+):
+    tokenizer = AutoTokenizer.from_pretrained(model_name)
+    tokenizer.pad_token = tokenizer.eos_token
+    train_ds, eval_ds = load_text_and_code_datasets(train_ratio)
+    tokenized_train = tokenize_dataset(tokenizer, train_ds)
+    tokenized_eval = tokenize_dataset(tokenizer, eval_ds)
+
+    model = AutoModelForCausalLM.from_pretrained(model_name)
+
+    data_collator = DataCollatorForLanguageModeling(tokenizer=tokenizer, mlm=False)
+
+    args = TrainingArguments(
+        output_dir=output_dir,
+        evaluation_strategy="epoch",
+        per_device_train_batch_size=batch_size,
+        num_train_epochs=epochs,
+        weight_decay=0.01,
+    )
+
+    trainer = Trainer(
+        model=model,
+        args=args,
+        train_dataset=tokenized_train,
+        eval_dataset=tokenized_eval,
+        data_collator=data_collator,
+    )
+
+    trainer.train()
+    metrics = trainer.evaluate()
+    metrics["perplexity"] = math.exp(metrics["eval_loss"])
+    print("Evaluation metrics", metrics)
+    trainer.save_model(output_dir)
+
+    if sample_prompt is not None:
+        inputs = tokenizer(sample_prompt, return_tensors="pt")
+        generated = trainer.model.generate(**inputs, max_length=50)
+        print(tokenizer.decode(generated[0], skip_special_tokens=True))
+
+
+def main(argv: List[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(description="Train the BNV model")
+    parser.add_argument(
+        "--output", default="./bnv_model", help="Directory to store the model"
+    )
+    parser.add_argument("--model", default="distilgpt2", help="Base model to fine-tune")
+    parser.add_argument(
+        "--epochs", type=int, default=1, help="Number of training epochs"
+    )
+    parser.add_argument("--batch-size", type=int, default=2, help="Training batch size")
+    parser.add_argument(
+        "--train-ratio",
+        type=float,
+        default=0.9,
+        help="Portion of data used for training",
+    )
+    parser.add_argument(
+        "--sample-prompt",
+        help="Optional prompt to generate text after training",
+    )
+    args = parser.parse_args(argv)
+    train(
+        output_dir=args.output,
+        model_name=args.model,
+        epochs=args.epochs,
+        batch_size=args.batch_size,
+        train_ratio=args.train_ratio,
+        sample_prompt=args.sample_prompt,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/bnv/train.py
+++ b/bnv/train.py
@@ -18,6 +18,7 @@ def load_text_and_code_datasets(
     train_ratio: float = 0.9,
     use_live_data: bool = False,
     wiki_topics: list[str] | None = None,
+    search_queries: list[str] | None = None,
 ) -> tuple[Dataset, Dataset]:
     """Load datasets for training.
 
@@ -25,7 +26,7 @@ def load_text_and_code_datasets(
     the packaged datasets.
     """
     if use_live_data:
-        samples = fetch_live_data(wiki_topics)
+        samples = fetch_live_data(wiki_topics, search_queries)
         combined = Dataset.from_dict({"text": samples})
     else:
         text_ds = load_dataset("wikitext", "wikitext-2-raw-v1", split="train")
@@ -53,11 +54,15 @@ def train(
     sample_prompt: str | None = None,
     use_live_data: bool = False,
     wiki_topics: list[str] | None = None,
+    search_queries: list[str] | None = None,
 ):
     tokenizer = AutoTokenizer.from_pretrained(model_name)
     tokenizer.pad_token = tokenizer.eos_token
     train_ds, eval_ds = load_text_and_code_datasets(
-        train_ratio, use_live_data=use_live_data, wiki_topics=wiki_topics
+        train_ratio,
+        use_live_data=use_live_data,
+        wiki_topics=wiki_topics,
+        search_queries=search_queries,
     )
     tokenized_train = tokenize_dataset(tokenizer, train_ds)
     tokenized_eval = tokenize_dataset(tokenizer, eval_ds)
@@ -125,6 +130,12 @@ def main(argv: List[str] | None = None) -> None:
         default=["Artificial_intelligence"],
         help="Topics for Wikipedia summaries when using live data",
     )
+    parser.add_argument(
+        "--search-queries",
+        nargs="*",
+        default=[],
+        help="Search queries to include when fetching live data",
+    )
     args = parser.parse_args(argv)
     train(
         output_dir=args.output,
@@ -135,6 +146,7 @@ def main(argv: List[str] | None = None) -> None:
         sample_prompt=args.sample_prompt,
         use_live_data=args.use_live_data,
         wiki_topics=args.wiki_topics,
+        search_queries=args.search_queries,
     )
 
 

--- a/bnv/train.py
+++ b/bnv/train.py
@@ -3,6 +3,8 @@ import math
 from typing import List
 
 from datasets import load_dataset, Dataset
+
+from .data_sources import fetch_live_data
 from transformers import (
     AutoTokenizer,
     AutoModelForCausalLM,
@@ -12,15 +14,24 @@ from transformers import (
 )
 
 
-def load_text_and_code_datasets(train_ratio: float = 0.9) -> tuple[Dataset, Dataset]:
-    """Load text and code datasets, merge them and split into train and eval sets."""
-    text_ds = load_dataset("wikitext", "wikitext-2-raw-v1", split="train")
-    code_ds = load_dataset("codeparrot/github-jupyter-text", split="train")
-    combined = Dataset.from_dict(
-        {
-            "text": text_ds["text"] + code_ds["content"],
-        }
-    )
+def load_text_and_code_datasets(
+    train_ratio: float = 0.9,
+    use_live_data: bool = False,
+    wiki_topics: list[str] | None = None,
+) -> tuple[Dataset, Dataset]:
+    """Load datasets for training.
+
+    If ``use_live_data`` is True, fetch text from several open APIs instead of
+    the packaged datasets.
+    """
+    if use_live_data:
+        samples = fetch_live_data(wiki_topics)
+        combined = Dataset.from_dict({"text": samples})
+    else:
+        text_ds = load_dataset("wikitext", "wikitext-2-raw-v1", split="train")
+        code_ds = load_dataset("codeparrot/github-jupyter-text", split="train")
+        combined = Dataset.from_dict({"text": text_ds["text"] + code_ds["content"]})
+
     split = combined.train_test_split(train_ratio, shuffle=True)
     return split["train"], split["test"]
 
@@ -40,10 +51,14 @@ def train(
     batch_size: int = 2,
     train_ratio: float = 0.9,
     sample_prompt: str | None = None,
+    use_live_data: bool = False,
+    wiki_topics: list[str] | None = None,
 ):
     tokenizer = AutoTokenizer.from_pretrained(model_name)
     tokenizer.pad_token = tokenizer.eos_token
-    train_ds, eval_ds = load_text_and_code_datasets(train_ratio)
+    train_ds, eval_ds = load_text_and_code_datasets(
+        train_ratio, use_live_data=use_live_data, wiki_topics=wiki_topics
+    )
     tokenized_train = tokenize_dataset(tokenizer, train_ds)
     tokenized_eval = tokenize_dataset(tokenizer, eval_ds)
 
@@ -99,6 +114,17 @@ def main(argv: List[str] | None = None) -> None:
         "--sample-prompt",
         help="Optional prompt to generate text after training",
     )
+    parser.add_argument(
+        "--use-live-data",
+        action="store_true",
+        help="Fetch training text from live APIs instead of local datasets",
+    )
+    parser.add_argument(
+        "--wiki-topics",
+        nargs="*",
+        default=["Artificial_intelligence"],
+        help="Topics for Wikipedia summaries when using live data",
+    )
     args = parser.parse_args(argv)
     train(
         output_dir=args.output,
@@ -107,6 +133,8 @@ def main(argv: List[str] | None = None) -> None:
         batch_size=args.batch_size,
         train_ratio=args.train_ratio,
         sample_prompt=args.sample_prompt,
+        use_live_data=args.use_live_data,
+        wiki_topics=args.wiki_topics,
     )
 
 


### PR DESCRIPTION
## Summary
- extend `train.py` to split datasets for training/evaluation
- add evaluation metrics, sample generation and CLI arguments
- document new training options in README

## Testing
- ❌ `python -m bnv.train --help | head -n 5` (failed to run due to missing `datasets`)


------
https://chatgpt.com/codex/tasks/task_e_6840ae6b7f0c83309f0f285f8a50b698